### PR TITLE
Char decoding

### DIFF
--- a/morss/morss.py
+++ b/morss/morss.py
@@ -701,7 +701,7 @@ def main():
         except (KeyboardInterrupt, SystemExit):
             raise
         except Exception as e:
-            print('ERROR: %s' % e.message)
+            print('ERROR\nmessage: ' + e.message +  '\ntype: ' + str(type(e)) + '\nargs: ' + str(e.args) + '\nexception: ' + str(e))
 
 if __name__ == '__main__':
     main()

--- a/morss/morss.py
+++ b/morss/morss.py
@@ -659,7 +659,18 @@ def cli_app():
     out = Format(rss, options)
 
     if not options.silent:
-        print(out.decode('utf-8', 'replace') if isinstance(out, bytes) else out)
+        if sys.version_info[0] > '3':
+            # for Python 3
+            if isinstance(out, bytes):
+                print(out.decode('utf-8', 'replace'))
+            else:
+                print(out)
+        else:
+            # for Python 2
+            if isinstance(out, unicode):
+                print(out.decode('utf-8', 'replace'))
+            else:
+                print(out)
 
     log('done')
 


### PR DESCRIPTION
isistance(out,bytes) for Python 2 doesn’t work very well.
Changed also the output of the Exception as it's possible that it doesn't contain a message.

This was an example error that I was getting

```
root@jolokia:~/git/morss# python -m morss debug http://www.repubblica.it/rss/homepage/rss2.0.xml > /var/www/html/rss/repubblica.xml
Traceback (most recent call last):
  File "/usr/lib/python2.7/runpy.py", line 162, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/usr/lib/python2.7/runpy.py", line 72, in _run_code
    exec code in run_globals
  File "/root/git/morss/morss/__main__.py", line 4, in <module>
    main()
  File "morss/morss.py", line 684, in main
    cli_app()
  File "morss/morss.py", line 668, in cli_app
    print(out.decode('utf-8', 'replace') if isinstance(out, bytes) else out)
UnicodeEncodeError: 'ascii' codec can't encode character u'\xe8' in position 3760: ordinal not in range(128)
```
