### PR TITLE
Add `mode` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,8 +395,8 @@ usage: morss [-h] [--post STRING] [--xpath XPATH]
              [--indent] [--cache] [--force] [--proxy]
              [--order {first,last,newest,oldest}] [--firstlink] [--resolve]
              [--items XPATH] [--item_link XPATH] [--item_title XPATH]
-             [--item_content XPATH] [--item_time XPATH] [--nolink] [--noref]
-             [--silent]
+             [--item_content XPATH] [--item_time XPATH]
+             [--mode {xml,html,json}] [--nolink] [--noref] [--silent]
              url
 
 Get full-text RSS feeds
@@ -440,6 +440,8 @@ custom feeds:
   --item_content XPATH  entry's content
   --item_time XPATH     entry's date & time (accepts a wide range of time
                         formats)
+  --mode {xml,html,json}
+                        parser to use for the custom feeds
 
 misc:
   --nolink              drop links, but keeps links' inner text

--- a/morss/cli.py
+++ b/morss/cli.py
@@ -54,6 +54,7 @@ def cli_app():
     group.add_argument('--item_title', action='store', type=str, metavar='XPATH', help='entry\'s title')
     group.add_argument('--item_content', action='store', type=str, metavar='XPATH', help='entry\'s content')
     group.add_argument('--item_time', action='store', type=str, metavar='XPATH', help='entry\'s date & time (accepts a wide range of time formats)')
+    group.add_argument('--mode', default=None, choices=('xml', 'html', 'json'), help='parser to use for the custom feeds')
 
     group = parser.add_argument_group('misc')
     group.add_argument('--nolink', action='store_true', help='drop links, but keeps links\' inner text')

--- a/morss/morss.py
+++ b/morss/morss.py
@@ -287,6 +287,9 @@ def FeedFetch(url, options):
 
         ruleset['items'] = options.items
 
+        if options.mode:
+            ruleset['mode'] = options.mode
+
         ruleset['title'] = options.get('title', '//head/title')
         ruleset['desc'] = options.get('desc', '//head/meta[@name="description"]/@content')
 


### PR DESCRIPTION
This PR adds the `mode` option.
It allows users to choose which parser to use when creating a custom feed.
If the `mode` is not specified, it will behave the same as before.

close #106 