### PR TITLE
Allow specifying a cookie jar file on command line

### DIFF
--- a/morss/cli.py
+++ b/morss/cli.py
@@ -60,6 +60,7 @@ def cli_app():
     group.add_argument('--nolink', action='store_true', help='drop links, but keeps links\' inner text')
     group.add_argument('--noref', action='store_true', help='drop items\' link')
     group.add_argument('--silent', action='store_true', help='don\'t output the final RSS (useless on its own, but can be nice when debugging)')
+    group.add_argument('--cookie-jar', action='store', help='Use a cookie jar for https requests')
 
     options = Options(vars(parser.parse_args()))
     url = options.url

--- a/morss/crawler.py
+++ b/morss/crawler.py
@@ -22,6 +22,7 @@ import re
 import sys
 import time
 import zlib
+from http import cookiejar
 from cgi import parse_header
 from collections import OrderedDict
 from io import BytesIO, StringIO
@@ -112,7 +113,7 @@ def adv_get(url, post=None, timeout=None, *args, **kwargs):
     }
 
 
-def custom_opener(follow=None, policy=None, force_min=None, force_max=None):
+def custom_opener(follow=None, policy=None, force_min=None, force_max=None, cookie_jar = None):
     # as per urllib2 source code, these Handelers are added first
     # *unless* one of the custom handlers inherits from one of them
     #
@@ -130,10 +131,14 @@ def custom_opener(follow=None, policy=None, force_min=None, force_max=None):
     # http_error_* are run until sth is returned (other than None). If they all
     # return nothing, a python error is raised
 
+    jar = None
+    if cookie_jar is not None:
+        jar = cookiejar.MozillaCookieJar(cookie_jar)
+        jar.load(cookie_jar)
     handlers = [
         #DebugHandler(),
         SizeLimitHandler(500*1024), # 500KiB
-        HTTPCookieProcessor(),
+        HTTPCookieProcessor(jar),
         GZIPHandler(),
         HTTPAllRedirectHandler(),
         HTTPEquivHandler(),

--- a/morss/morss.py
+++ b/morss/morss.py
@@ -208,7 +208,7 @@ def ItemFill(item, options, feedurl='/', fast=False):
         policy = None
 
     try:
-        req = crawler.adv_get(url=item.link, policy=policy, force_min=24*60*60, timeout=TIMEOUT)
+        req = crawler.adv_get(url=item.link, policy=policy, force_min=24*60*60, timeout=TIMEOUT, cookie_jar=options.cookie_jar)
 
     except (IOError, HTTPException) as e:
         log('http error')
@@ -276,7 +276,7 @@ def FeedFetch(url, options):
         policy = None
 
     try:
-        req = crawler.adv_get(url=url, post=options.post, follow=('rss' if not options.items else None), policy=policy, force_min=5*60, force_max=60*60, timeout=TIMEOUT)
+        req = crawler.adv_get(url=url, post=options.post, follow=('rss' if not options.items else None), policy=policy, force_min=5*60, force_max=60*60, timeout=TIMEOUT, cookie_jar=options.cookie_jar)
 
     except (IOError, HTTPException):
         raise MorssException('Error downloading feed')


### PR DESCRIPTION
This is useful to me to make full-text rss of my paying subscriptions.

Exposing it only for CLI doesn't seem optimal, so I'm guessing it won't be merged without server support. But I don't really know how to deal with it. (can't really put the cookies in the URL) Any recommendations?